### PR TITLE
fixed assign float

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -626,6 +626,9 @@ class Visitor {
       this.emit('null');
     } else if (ast.type === 'number') {
       this.emit(ast.value.value);
+      if (ast.value.type === 'float') {
+        this.emit('f');
+      }
     } else if (ast.type === 'object') {
       this.visitObject(ast, level, env);
     } else if (ast.type === 'variable') {

--- a/test/expected/complex/core/Client.cs
+++ b/test/expected/complex/core/Client.cs
@@ -56,6 +56,11 @@ namespace Darabonba.Test
                 {
                     TeaRequest request_ = new TeaRequest();
                     string name = "complex";
+                    Config conf = new Config
+                    {
+                        FloatNum = 0.1f,
+                    };
+                    conf.FloatNum = 1.1f;
                     Dictionary<string, string> mapVal = new Dictionary<string, string>
                     {
                         {"test", "ok"},
@@ -137,6 +142,11 @@ namespace Darabonba.Test
                 {
                     TeaRequest request_ = new TeaRequest();
                     string name = "complex";
+                    Config conf = new Config
+                    {
+                        FloatNum = 0.1f,
+                    };
+                    conf.FloatNum = 1.1f;
                     Dictionary<string, string> mapVal = new Dictionary<string, string>
                     {
                         {"test", "ok"},

--- a/test/expected/complex/core/Models/Config.cs
+++ b/test/expected/complex/core/Models/Config.cs
@@ -25,6 +25,10 @@ namespace Darabonba.Test.Models
         [Validation(Required=true)]
         public List<List<string>> ComplexList { get; set; }
 
+        [NameInMap("floatNum")]
+        [Validation(Required=true)]
+        public float? FloatNum { get; set; }
+
     }
 
 }

--- a/test/fixtures/complex/main.dara
+++ b/test/fixtures/complex/main.dara
@@ -6,7 +6,8 @@ model Config {
   protocol: string(maxLength= 50, pattern= 'pattern'),
   importConfig: Source.Config,
   query: string,
-  complexList: [[string]]
+  complexList: [[string]],
+  floatNum: float
 }
 type @protocol = string
 type @pathname = string
@@ -55,6 +56,8 @@ static async function print(reqeust: $Request, reqs: [ ComplexRequest ], respons
 
 api Complex1(request: ComplexRequest, client: Source): Source.RuntimeObject {
   var name = 'complex';
+  var conf = new Config{ floatNum = 0.1 };
+  conf.floatNum = 1.1;
   var mapVal = {
     test="ok"
     };


### PR DESCRIPTION
* 增加对 float 类型参数赋值时的判断，编译器默认浮点型数值为 double 类型，由于精度问题 double 类型不能隐式转换为 float，须在数值后增加 f ，申明该数值为单精度浮点型。